### PR TITLE
Fix multiple values for custom field

### DIFF
--- a/redirect-301/src/main/webapp/META-INF/custom_jsps/html/common/forward_jsp.jsp
+++ b/redirect-301/src/main/webapp/META-INF/custom_jsps/html/common/forward_jsp.jsp
@@ -26,10 +26,7 @@
 				response.setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY);
 				response.setHeader("Location", forwardURL);			 
 				break;
-			 } 
-			else{
-				response.sendRedirect(forwardURL);
-			}					
+			 }
 		}
 	}		 
 	else {


### PR DESCRIPTION
When you had multiple values in the "pages-with-redirect-301" custom fields, like "/link-01, /link-02, /link-03, ...", the 301 redirect was working only for the first value (/link-01 for this example), and the other ones were still getting 302. This PR fixes that issue so all values are going to use 301 redirects.